### PR TITLE
Temporarily remove VS Code plugins

### DIFF
--- a/do500-factory.json
+++ b/do500-factory.json
@@ -95,8 +95,8 @@
     ],
     "name": "do500",
     "attributes": {
-      "editor": "org.eclipse.che.editor.theia:next",
-      "plugins": "che-machine-exec-plugin:0.0.1,ms-vscode.node-debug2:1.31.6,redhat.vscode-yaml:0.4.0,redhat.vscode-openshift-connector:0.0.19"
+      "editor": "org.eclipse.che.editor.theia:1.0.0",
+      "plugins": "che-machine-exec-plugin:0.0.1"
     },
     "commands": [
       {


### PR DESCRIPTION
@makentenza @springdo 

Here are the temp changes necessary to have a functional CRW. Everything else stays the same, just needed to temporarily remove any of the `vsix` plugins.